### PR TITLE
Fix NRT errors and enable TreatWarningsAsErrors

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,6 +16,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/src/Foundatio.Minio/Foundatio.Minio.csproj
+++ b/src/Foundatio.Minio/Foundatio.Minio.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Minio" Version="7.0.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Minio/Foundatio.Minio.csproj
+++ b/src/Foundatio.Minio/Foundatio.Minio.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Minio" Version="7.0.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Minio/Foundatio.Minio.csproj
+++ b/src/Foundatio.Minio/Foundatio.Minio.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Minio" Version="7.0.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Minio/Foundatio.Minio.csproj
+++ b/src/Foundatio.Minio/Foundatio.Minio.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Minio" Version="7.0.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
@@ -18,8 +18,7 @@ public class MinioConnectionStringBuilder
 
     protected MinioConnectionStringBuilder(string connectionString)
     {
-        if (String.IsNullOrEmpty(connectionString))
-            throw new ArgumentNullException(nameof(connectionString));
+        ArgumentException.ThrowIfNullOrEmpty(connectionString);
         Parse(connectionString);
     }
 

--- a/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
@@ -1,17 +1,17 @@
-﻿using System;
+using System;
 using System.Linq;
 
 namespace Foundatio;
 
 public class MinioConnectionStringBuilder
 {
-    public string AccessKey { get; set; }
+    public string AccessKey { get; set; } = null!;
 
-    public string SecretKey { get; set; }
+    public string SecretKey { get; set; } = null!;
 
-    public string Region { get; set; }
+    public string Region { get; set; } = null!;
 
-    public string EndPoint { get; set; }
+    public string EndPoint { get; set; } = null!;
 
     protected MinioConnectionStringBuilder() { }
 

--- a/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
@@ -5,13 +5,13 @@ namespace Foundatio;
 
 public class MinioConnectionStringBuilder
 {
-    public string AccessKey { get; set; } = null!;
+    public string AccessKey { get; set; } = string.Empty;
 
-    public string SecretKey { get; set; } = null!;
+    public string SecretKey { get; set; } = string.Empty;
 
-    public string Region { get; set; } = null!;
+    public string Region { get; set; } = string.Empty;
 
-    public string EndPoint { get; set; } = null!;
+    public string EndPoint { get; set; } = string.Empty;
 
     protected MinioConnectionStringBuilder() { }
 

--- a/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
@@ -1,17 +1,18 @@
 using System;
 using System.Linq;
+using System.Text;
 
 namespace Foundatio;
 
 public class MinioConnectionStringBuilder
 {
-    public string AccessKey { get; set; } = String.Empty;
+    public string? AccessKey { get; set; }
 
-    public string SecretKey { get; set; } = String.Empty;
+    public string? SecretKey { get; set; }
 
-    public string Region { get; set; } = String.Empty;
+    public string? Region { get; set; }
 
-    public string EndPoint { get; set; } = String.Empty;
+    public string? EndPoint { get; set; }
 
     protected MinioConnectionStringBuilder() { }
 
@@ -74,15 +75,15 @@ public class MinioConnectionStringBuilder
 
     public override string ToString()
     {
-        var connectionString = String.Empty;
+        var sb = new StringBuilder();
         if (!String.IsNullOrEmpty(AccessKey))
-            connectionString += "AccessKey=" + AccessKey + ";";
+            sb.Append("AccessKey=").Append(AccessKey).Append(';');
         if (!String.IsNullOrEmpty(SecretKey))
-            connectionString += "SecretKey=" + SecretKey + ";";
+            sb.Append("SecretKey=").Append(SecretKey).Append(';');
         if (!String.IsNullOrEmpty(Region))
-            connectionString += "Region=" + Region + ";";
+            sb.Append("Region=").Append(Region).Append(';');
         if (!String.IsNullOrEmpty(EndPoint))
-            connectionString += "EndPoint=" + EndPoint + ";";
-        return connectionString;
+            sb.Append("EndPoint=").Append(EndPoint).Append(';');
+        return sb.ToString();
     }
 }

--- a/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/MinioConnectionStringBuilder.cs
@@ -5,13 +5,13 @@ namespace Foundatio;
 
 public class MinioConnectionStringBuilder
 {
-    public string AccessKey { get; set; } = string.Empty;
+    public string AccessKey { get; set; } = String.Empty;
 
-    public string SecretKey { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = String.Empty;
 
-    public string Region { get; set; } = string.Empty;
+    public string Region { get; set; } = String.Empty;
 
-    public string EndPoint { get; set; } = string.Empty;
+    public string EndPoint { get; set; } = String.Empty;
 
     protected MinioConnectionStringBuilder() { }
 
@@ -74,14 +74,14 @@ public class MinioConnectionStringBuilder
 
     public override string ToString()
     {
-        var connectionString = string.Empty;
-        if (!string.IsNullOrEmpty(AccessKey))
+        var connectionString = String.Empty;
+        if (!String.IsNullOrEmpty(AccessKey))
             connectionString += "AccessKey=" + AccessKey + ";";
-        if (!string.IsNullOrEmpty(SecretKey))
+        if (!String.IsNullOrEmpty(SecretKey))
             connectionString += "SecretKey=" + SecretKey + ";";
-        if (!string.IsNullOrEmpty(Region))
+        if (!String.IsNullOrEmpty(Region))
             connectionString += "Region=" + Region + ";";
-        if (!string.IsNullOrEmpty(EndPoint))
+        if (!String.IsNullOrEmpty(EndPoint))
             connectionString += "EndPoint=" + EndPoint + ";";
         return connectionString;
     }

--- a/src/Foundatio.Minio/Storage/MinioFileStorage.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorage.cs
@@ -318,7 +318,7 @@ public class MinioFileStorage : IFileStorage
 
         _logger.LogTrace(
             s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
-            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, (object?)criteria.Pattern ?? "(none)"
+            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern
         );
 
         await foreach (var item in _client.ListObjectsEnumAsync(
@@ -359,8 +359,8 @@ public class MinioFileStorage : IFileStorage
 
     private record SearchCriteria
     {
-        public required string Prefix { get; set; }
-        public Regex? Pattern { get; set; }
+        public required string Prefix { get; init; }
+        public Regex? Pattern { get; init; }
     }
 
     private SearchCriteria GetRequestCriteria(string? searchPattern)

--- a/src/Foundatio.Minio/Storage/MinioFileStorage.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorage.cs
@@ -63,10 +63,10 @@ public class MinioFileStorage : IFileStorage
     }
 
     [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(FileAccess)} instead to define read or write behaviour of stream")]
-    public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
+    public Task<Stream?> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
         => GetFileStreamAsync(path, StreamMode.Read, cancellationToken);
 
-    public async Task<Stream> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
+    public async Task<Stream?> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
     {
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
@@ -93,7 +93,7 @@ public class MinioFileStorage : IFileStorage
         }
     }
 
-    public async Task<FileSpec> GetFileInfoAsync(string path)
+    public async Task<FileSpec?> GetFileInfoAsync(string path)
     {
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
@@ -106,7 +106,7 @@ public class MinioFileStorage : IFileStorage
         try
         {
             var metadata = await _client.StatObjectAsync(new StatObjectArgs().WithBucket(_bucket).WithObject(normalizedPath)).AnyContext();
-            if (metadata.ExtraHeaders.TryGetValue("X-Minio-Error-Code", out string errorCode) && (String.Equals(errorCode, "NoSuchBucket") || String.Equals(errorCode, "NoSuchKey")))
+            if (metadata.ExtraHeaders.TryGetValue("X-Minio-Error-Code", out string? errorCode) && (String.Equals(errorCode, "NoSuchBucket") || String.Equals(errorCode, "NoSuchKey")))
                 return null;
 
             return new FileSpec
@@ -137,7 +137,7 @@ public class MinioFileStorage : IFileStorage
         try
         {
             var metadata = await _client.StatObjectAsync(new StatObjectArgs().WithBucket(_bucket).WithObject(normalizedPath)).AnyContext();
-            if (metadata.ExtraHeaders.TryGetValue("X-Minio-Error-Code", out string errorCode) && (String.Equals(errorCode, "NoSuchBucket") || String.Equals(errorCode, "NoSuchKey")))
+            if (metadata.ExtraHeaders.TryGetValue("X-Minio-Error-Code", out string? errorCode) && (String.Equals(errorCode, "NoSuchBucket") || String.Equals(errorCode, "NoSuchKey")))
                 return false;
 
             return true;
@@ -254,7 +254,7 @@ public class MinioFileStorage : IFileStorage
         }
     }
 
-    public async Task<int> DeleteFilesAsync(string searchPattern = null, CancellationToken cancellation = default)
+    public async Task<int> DeleteFilesAsync(string? searchPattern = null, CancellationToken cancellation = default)
     {
         await EnsureBucketExists().AnyContext();
 
@@ -283,7 +283,7 @@ public class MinioFileStorage : IFileStorage
         return count;
     }
 
-    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string searchPattern = null, CancellationToken cancellationToken = default)
+    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string? searchPattern = null, CancellationToken cancellationToken = default)
     {
         if (pageSize <= 0)
             return PagedFileListResult.Empty;
@@ -295,7 +295,7 @@ public class MinioFileStorage : IFileStorage
         return result;
     }
 
-    private async Task<NextPageResult> GetFiles(string searchPattern, int page, int pageSize, CancellationToken cancellationToken)
+    private async Task<NextPageResult> GetFiles(string? searchPattern, int page, int pageSize, CancellationToken cancellationToken)
     {
         int pagingLimit = pageSize;
         int skip = (page - 1) * pagingLimit;
@@ -319,7 +319,7 @@ public class MinioFileStorage : IFileStorage
         };
     }
 
-    private async Task<List<FileSpec>> GetFileListAsync(string searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default)
+    private async Task<List<FileSpec>> GetFileListAsync(string? searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default)
     {
         if (limit is <= 0)
             return new List<FileSpec>();
@@ -329,7 +329,7 @@ public class MinioFileStorage : IFileStorage
 
         _logger.LogTrace(
             s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
-            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern
+            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern!
         );
 
         await foreach (var item in _client.ListObjectsEnumAsync(
@@ -365,16 +365,16 @@ public class MinioFileStorage : IFileStorage
 
     private string NormalizePath(string path)
     {
-        return path?.Replace('\\', '/');
+        return path.Replace('\\', '/');
     }
 
     private class SearchCriteria
     {
-        public string Prefix { get; set; }
-        public Regex Pattern { get; set; }
+        public string Prefix { get; set; } = null!;
+        public Regex? Pattern { get; set; }
     }
 
-    private SearchCriteria GetRequestCriteria(string searchPattern)
+    private SearchCriteria GetRequestCriteria(string? searchPattern)
     {
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
@@ -384,7 +384,7 @@ public class MinioFileStorage : IFileStorage
         bool hasWildcard = wildcardPos >= 0;
 
         string prefix = normalizedSearchPattern;
-        Regex patternRegex = null;
+        Regex? patternRegex = null;
 
         if (hasWildcard)
         {

--- a/src/Foundatio.Minio/Storage/MinioFileStorage.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorage.cs
@@ -329,7 +329,7 @@ public class MinioFileStorage : IFileStorage
 
         _logger.LogTrace(
             s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
-            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern!
+            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, (object?)criteria.Pattern ?? "(none)"
         );
 
         await foreach (var item in _client.ListObjectsEnumAsync(
@@ -370,7 +370,7 @@ public class MinioFileStorage : IFileStorage
 
     private class SearchCriteria
     {
-        public string Prefix { get; set; } = string.Empty;
+        public string Prefix { get; set; } = String.Empty;
         public Regex? Pattern { get; set; }
     }
 
@@ -402,10 +402,13 @@ public class MinioFileStorage : IFileStorage
 
     private (IMinioClient Client, string Bucket) CreateClient(MinioFileStorageOptions options)
     {
+        if (String.IsNullOrEmpty(options.ConnectionString))
+            throw new ArgumentException("ConnectionString is required.", nameof(options.ConnectionString));
+
         var connectionString = new MinioFileStorageConnectionStringBuilder(options.ConnectionString);
 
         if (String.IsNullOrEmpty(connectionString.EndPoint))
-            throw new ArgumentException("EndPoint is required in the connection string.", nameof(options));
+            throw new ArgumentException("EndPoint is required in the connection string.", nameof(options.ConnectionString));
 
         string endpoint;
         bool secure;

--- a/src/Foundatio.Minio/Storage/MinioFileStorage.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorage.cs
@@ -155,12 +155,23 @@ public class MinioFileStorage : IFileStorage
         string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Saving {Path}", normalizedPath);
 
-        var seekableStream = stream.CanSeek ? stream : new MemoryStream();
-        if (!stream.CanSeek)
+        if (stream.CanSeek)
         {
-            await stream.CopyToAsync(seekableStream).AnyContext();
-            seekableStream.Seek(0, SeekOrigin.Begin);
+            try
+            {
+                await _client.PutObjectAsync(new PutObjectArgs().WithBucket(_bucket).WithObject(normalizedPath).WithStreamData(stream).WithObjectSize(stream.Length - stream.Position), cancellationToken).AnyContext();
+                return true;
+            }
+            catch (MinioException ex)
+            {
+                _logger.LogError(ex, "Error saving {Path}: {Message}", normalizedPath, ex.Message);
+                return false;
+            }
         }
+
+        using var seekableStream = new MemoryStream();
+        await stream.CopyToAsync(seekableStream).AnyContext();
+        seekableStream.Seek(0, SeekOrigin.Begin);
 
         try
         {
@@ -171,11 +182,6 @@ public class MinioFileStorage : IFileStorage
         {
             _logger.LogError(ex, "Error saving {Path}: {Message}", normalizedPath, ex.Message);
             return false;
-        }
-        finally
-        {
-            if (!stream.CanSeek)
-                seekableStream.Dispose();
         }
     }
 
@@ -413,10 +419,8 @@ public class MinioFileStorage : IFileStorage
         }
 
         var client = new MinioClient()
-            .WithEndpoint(endpoint);
-
-        if (!String.IsNullOrEmpty(connectionString.AccessKey) && !String.IsNullOrEmpty(connectionString.SecretKey))
-            client.WithCredentials(connectionString.AccessKey, connectionString.SecretKey);
+            .WithEndpoint(endpoint)
+            .WithCredentials(connectionString.AccessKey, connectionString.SecretKey);
 
         if (!String.IsNullOrEmpty(connectionString.Region))
             client.WithRegion(connectionString.Region);
@@ -429,5 +433,8 @@ public class MinioFileStorage : IFileStorage
         return (client, connectionString.Bucket);
     }
 
-    public void Dispose() { }
+    public void Dispose()
+    {
+        _client.Dispose();
+    }
 }

--- a/src/Foundatio.Minio/Storage/MinioFileStorage.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorage.cs
@@ -370,7 +370,7 @@ public class MinioFileStorage : IFileStorage
 
     private class SearchCriteria
     {
-        public string Prefix { get; set; } = null!;
+        public string Prefix { get; set; } = string.Empty;
         public Regex? Pattern { get; set; }
     }
 
@@ -404,6 +404,9 @@ public class MinioFileStorage : IFileStorage
     {
         var connectionString = new MinioFileStorageConnectionStringBuilder(options.ConnectionString);
 
+        if (String.IsNullOrEmpty(connectionString.EndPoint))
+            throw new ArgumentException("EndPoint is required in the connection string.", nameof(options));
+
         string endpoint;
         bool secure;
         if (connectionString.EndPoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
@@ -424,7 +427,7 @@ public class MinioFileStorage : IFileStorage
             .WithCredentials(connectionString.AccessKey, connectionString.SecretKey);
 
         if (!String.IsNullOrEmpty(connectionString.Region))
-            client.WithRegion(connectionString.Region ?? String.Empty);
+            client.WithRegion(connectionString.Region);
 
         client.Build();
 

--- a/src/Foundatio.Minio/Storage/MinioFileStorage.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorage.cs
@@ -426,8 +426,10 @@ public class MinioFileStorage : IFileStorage
         }
 
         var client = new MinioClient()
-            .WithEndpoint(endpoint)
-            .WithCredentials(connectionString.AccessKey, connectionString.SecretKey);
+            .WithEndpoint(endpoint);
+
+        if (!String.IsNullOrEmpty(connectionString.AccessKey) && !String.IsNullOrEmpty(connectionString.SecretKey))
+            client.WithCredentials(connectionString.AccessKey, connectionString.SecretKey);
 
         if (!String.IsNullOrEmpty(connectionString.Region))
             client.WithRegion(connectionString.Region);

--- a/src/Foundatio.Minio/Storage/MinioFileStorage.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorage.cs
@@ -74,7 +74,7 @@ public class MinioFileStorage : IFileStorage
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Getting file stream for {Path}", normalizedPath);
 
         try
@@ -97,7 +97,7 @@ public class MinioFileStorage : IFileStorage
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
         try
@@ -127,7 +127,7 @@ public class MinioFileStorage : IFileStorage
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Checking if {Path} exists", normalizedPath);
 
         try
@@ -152,26 +152,15 @@ public class MinioFileStorage : IFileStorage
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Saving {Path}", normalizedPath);
 
-        if (stream.CanSeek)
+        var seekableStream = stream.CanSeek ? stream : new MemoryStream();
+        if (!stream.CanSeek)
         {
-            try
-            {
-                await _client.PutObjectAsync(new PutObjectArgs().WithBucket(_bucket).WithObject(normalizedPath).WithStreamData(stream).WithObjectSize(stream.Length - stream.Position), cancellationToken).AnyContext();
-                return true;
-            }
-            catch (MinioException ex)
-            {
-                _logger.LogError(ex, "Error saving {Path}: {Message}", normalizedPath, ex.Message);
-                return false;
-            }
+            await stream.CopyToAsync(seekableStream).AnyContext();
+            seekableStream.Seek(0, SeekOrigin.Begin);
         }
-
-        using var seekableStream = new MemoryStream();
-        await stream.CopyToAsync(seekableStream).AnyContext();
-        seekableStream.Seek(0, SeekOrigin.Begin);
 
         try
         {
@@ -183,6 +172,11 @@ public class MinioFileStorage : IFileStorage
             _logger.LogError(ex, "Error saving {Path}: {Message}", normalizedPath, ex.Message);
             return false;
         }
+        finally
+        {
+            if (!stream.CanSeek)
+                seekableStream.Dispose();
+        }
     }
 
     public async Task<bool> RenameFileAsync(string path, string newPath, CancellationToken cancellationToken = default)
@@ -192,8 +186,8 @@ public class MinioFileStorage : IFileStorage
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path)!;
-        string normalizedNewPath = NormalizePath(newPath)!;
+        string normalizedPath = NormalizePath(path);
+        string normalizedNewPath = NormalizePath(newPath);
         _logger.LogInformation("Renaming {Path} to {NewPath}", normalizedPath, normalizedNewPath);
 
         return await CopyFileAsync(normalizedPath, normalizedNewPath, cancellationToken).AnyContext() &&
@@ -207,8 +201,8 @@ public class MinioFileStorage : IFileStorage
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path)!;
-        string normalizedTargetPath = NormalizePath(targetPath)!;
+        string normalizedPath = NormalizePath(path);
+        string normalizedTargetPath = NormalizePath(targetPath);
         _logger.LogInformation("Copying {Path} to {TargetPath}", normalizedPath, normalizedTargetPath);
 
         try
@@ -234,7 +228,7 @@ public class MinioFileStorage : IFileStorage
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Deleting {Path}", normalizedPath);
 
         try
@@ -263,7 +257,7 @@ public class MinioFileStorage : IFileStorage
                 break;
 
             var args = new RemoveObjectsArgs().WithBucket(_bucket)
-                .WithObjects(result.Files.Select(spec => NormalizePath(spec.Path)!).ToList());
+                .WithObjects(result.Files.Select(spec => NormalizePath(spec.Path)).ToList());
 
             var response = await _client.RemoveObjectsAsync(args, cancellation).AnyContext();
             count += result.Files.Count;
@@ -358,9 +352,9 @@ public class MinioFileStorage : IFileStorage
         }).ToList();
     }
 
-    private string? NormalizePath(string? path)
+    private string NormalizePath(string path)
     {
-        return path?.Replace('\\', '/');
+        return path.Replace('\\', '/');
     }
 
     private record SearchCriteria
@@ -374,7 +368,7 @@ public class MinioFileStorage : IFileStorage
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
 
-        string normalizedSearchPattern = NormalizePath(searchPattern)!;
+        string normalizedSearchPattern = NormalizePath(searchPattern);
         int wildcardPos = normalizedSearchPattern.IndexOf('*');
         bool hasWildcard = wildcardPos >= 0;
 

--- a/src/Foundatio.Minio/Storage/MinioFileStorage.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorage.cs
@@ -27,8 +27,7 @@ public class MinioFileStorage : IFileStorage
 
     public MinioFileStorage(MinioFileStorageOptions options)
     {
-        if (options == null)
-            throw new ArgumentNullException(nameof(options));
+        ArgumentNullException.ThrowIfNull(options);
 
         _serializer = options.Serializer ?? DefaultSerializer.Instance;
         _logger = options.LoggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
@@ -68,15 +67,14 @@ public class MinioFileStorage : IFileStorage
 
     public async Task<Stream?> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
     {
-        if (String.IsNullOrEmpty(path))
-            throw new ArgumentNullException(nameof(path));
+        ArgumentException.ThrowIfNullOrEmpty(path);
 
         if (streamMode is StreamMode.Write)
             throw new NotSupportedException($"Stream mode {streamMode} is not supported.");
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Getting file stream for {Path}", normalizedPath);
 
         try
@@ -86,7 +84,7 @@ public class MinioFileStorage : IFileStorage
             result.Seek(0, SeekOrigin.Begin);
             return result;
         }
-        catch (Exception ex)
+        catch (MinioException ex)
         {
             _logger.LogError(ex, "Unable to get file stream for {Path}: {Message}", normalizedPath, ex.Message);
             return null;
@@ -95,12 +93,11 @@ public class MinioFileStorage : IFileStorage
 
     public async Task<FileSpec?> GetFileInfoAsync(string path)
     {
-        if (String.IsNullOrEmpty(path))
-            throw new ArgumentNullException(nameof(path));
+        ArgumentException.ThrowIfNullOrEmpty(path);
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
         try
@@ -117,21 +114,20 @@ public class MinioFileStorage : IFileStorage
                 Modified = metadata.LastModified.ToUniversalTime()
             };
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is ObjectNotFoundException or BucketNotFoundException)
         {
-            _logger.LogError(ex, "Unable to get file info for {Path}: {Message}", normalizedPath, ex.Message);
+            _logger.LogDebug(ex, "Unable to get file info for {Path}: {Message}", normalizedPath, ex.Message);
             return null;
         }
     }
 
     public async Task<bool> ExistsAsync(string path)
     {
-        if (String.IsNullOrEmpty(path))
-            throw new ArgumentNullException(nameof(path));
+        ArgumentException.ThrowIfNullOrEmpty(path);
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Checking if {Path} exists", normalizedPath);
 
         try
@@ -151,14 +147,12 @@ public class MinioFileStorage : IFileStorage
 
     public async Task<bool> SaveFileAsync(string path, Stream stream, CancellationToken cancellationToken = default)
     {
-        if (String.IsNullOrEmpty(path))
-            throw new ArgumentNullException(nameof(path));
-        if (stream == null)
-            throw new ArgumentNullException(nameof(stream));
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentNullException.ThrowIfNull(stream);
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Saving {Path}", normalizedPath);
 
         var seekableStream = stream.CanSeek ? stream : new MemoryStream();
@@ -173,7 +167,7 @@ public class MinioFileStorage : IFileStorage
             await _client.PutObjectAsync(new PutObjectArgs().WithBucket(_bucket).WithObject(normalizedPath).WithStreamData(seekableStream).WithObjectSize(seekableStream.Length - seekableStream.Position), cancellationToken).AnyContext();
             return true;
         }
-        catch (Exception ex)
+        catch (MinioException ex)
         {
             _logger.LogError(ex, "Error saving {Path}: {Message}", normalizedPath, ex.Message);
             return false;
@@ -187,15 +181,13 @@ public class MinioFileStorage : IFileStorage
 
     public async Task<bool> RenameFileAsync(string path, string newPath, CancellationToken cancellationToken = default)
     {
-        if (String.IsNullOrEmpty(path))
-            throw new ArgumentNullException(nameof(path));
-        if (String.IsNullOrEmpty(newPath))
-            throw new ArgumentNullException(nameof(newPath));
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentException.ThrowIfNullOrEmpty(newPath);
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path);
-        string normalizedNewPath = NormalizePath(newPath);
+        string normalizedPath = NormalizePath(path)!;
+        string normalizedNewPath = NormalizePath(newPath)!;
         _logger.LogInformation("Renaming {Path} to {NewPath}", normalizedPath, normalizedNewPath);
 
         return await CopyFileAsync(normalizedPath, normalizedNewPath, cancellationToken).AnyContext() &&
@@ -204,15 +196,13 @@ public class MinioFileStorage : IFileStorage
 
     public async Task<bool> CopyFileAsync(string path, string targetPath, CancellationToken cancellationToken = default)
     {
-        if (String.IsNullOrEmpty(path))
-            throw new ArgumentNullException(nameof(path));
-        if (String.IsNullOrEmpty(targetPath))
-            throw new ArgumentNullException(nameof(targetPath));
+        ArgumentException.ThrowIfNullOrEmpty(path);
+        ArgumentException.ThrowIfNullOrEmpty(targetPath);
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path);
-        string normalizedTargetPath = NormalizePath(targetPath);
+        string normalizedPath = NormalizePath(path)!;
+        string normalizedTargetPath = NormalizePath(targetPath)!;
         _logger.LogInformation("Copying {Path} to {TargetPath}", normalizedPath, normalizedTargetPath);
 
         try
@@ -225,7 +215,7 @@ public class MinioFileStorage : IFileStorage
                 .WithCopyObjectSource(copySourceArgs), cancellationToken).AnyContext();
             return true;
         }
-        catch (Exception ex)
+        catch (MinioException ex)
         {
             _logger.LogError(ex, "Error copying {Path} to {TargetPath}: {Message}", normalizedPath, normalizedTargetPath, ex.Message);
             return false;
@@ -234,12 +224,11 @@ public class MinioFileStorage : IFileStorage
 
     public async Task<bool> DeleteFileAsync(string path, CancellationToken cancellationToken = default)
     {
-        if (String.IsNullOrEmpty(path))
-            throw new ArgumentNullException(nameof(path));
+        ArgumentException.ThrowIfNullOrEmpty(path);
 
         await EnsureBucketExists().AnyContext();
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Deleting {Path}", normalizedPath);
 
         try
@@ -247,7 +236,7 @@ public class MinioFileStorage : IFileStorage
             await _client.RemoveObjectAsync(new RemoveObjectArgs().WithBucket(_bucket).WithObject(normalizedPath), cancellationToken).AnyContext();
             return true;
         }
-        catch (Exception ex)
+        catch (MinioException ex)
         {
             _logger.LogError(ex, "Unable to delete {Path}: {Message}", normalizedPath, ex.Message);
             return false;
@@ -268,7 +257,7 @@ public class MinioFileStorage : IFileStorage
                 break;
 
             var args = new RemoveObjectsArgs().WithBucket(_bucket)
-                .WithObjects(result.Files.Select(spec => NormalizePath(spec.Path)).ToList());
+                .WithObjects(result.Files.Select(spec => NormalizePath(spec.Path)!).ToList());
 
             var response = await _client.RemoveObjectsAsync(args, cancellation).AnyContext();
             count += result.Files.Count;
@@ -363,14 +352,14 @@ public class MinioFileStorage : IFileStorage
         }).ToList();
     }
 
-    private string NormalizePath(string path)
+    private string? NormalizePath(string? path)
     {
-        return path.Replace('\\', '/');
+        return path?.Replace('\\', '/');
     }
 
-    private class SearchCriteria
+    private record SearchCriteria
     {
-        public string Prefix { get; set; } = String.Empty;
+        public required string Prefix { get; set; }
         public Regex? Pattern { get; set; }
     }
 
@@ -379,7 +368,7 @@ public class MinioFileStorage : IFileStorage
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
 
-        string normalizedSearchPattern = NormalizePath(searchPattern);
+        string normalizedSearchPattern = NormalizePath(searchPattern)!;
         int wildcardPos = normalizedSearchPattern.IndexOf('*');
         bool hasWildcard = wildcardPos >= 0;
 
@@ -402,13 +391,11 @@ public class MinioFileStorage : IFileStorage
 
     private (IMinioClient Client, string Bucket) CreateClient(MinioFileStorageOptions options)
     {
-        if (String.IsNullOrEmpty(options.ConnectionString))
-            throw new ArgumentException("ConnectionString is required.", nameof(options.ConnectionString));
+        ArgumentException.ThrowIfNullOrEmpty(options.ConnectionString, nameof(options.ConnectionString));
 
         var connectionString = new MinioFileStorageConnectionStringBuilder(options.ConnectionString);
 
-        if (String.IsNullOrEmpty(connectionString.EndPoint))
-            throw new ArgumentException("EndPoint is required in the connection string.", nameof(options.ConnectionString));
+        ArgumentException.ThrowIfNullOrEmpty(connectionString.EndPoint, nameof(connectionString.EndPoint));
 
         string endpoint;
         bool secure;

--- a/src/Foundatio.Minio/Storage/MinioFileStorageConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorageConnectionStringBuilder.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Storage;
 
 public class MinioFileStorageConnectionStringBuilder : MinioConnectionStringBuilder
 {
-    private string _bucket;
+    private string _bucket = null!;
 
     public MinioFileStorageConnectionStringBuilder()
     {

--- a/src/Foundatio.Minio/Storage/MinioFileStorageConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorageConnectionStringBuilder.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Storage;
 
 public class MinioFileStorageConnectionStringBuilder : MinioConnectionStringBuilder
 {
-    private string _bucket = null!;
+    private string _bucket = string.Empty;
 
     public MinioFileStorageConnectionStringBuilder()
     {

--- a/src/Foundatio.Minio/Storage/MinioFileStorageConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorageConnectionStringBuilder.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Text;
 
 namespace Foundatio.Storage;
 
 public class MinioFileStorageConnectionStringBuilder : MinioConnectionStringBuilder
 {
-    private string _bucket = String.Empty;
+    private string? _bucket;
 
     public MinioFileStorageConnectionStringBuilder()
     {
@@ -32,9 +33,9 @@ public class MinioFileStorageConnectionStringBuilder : MinioConnectionStringBuil
 
     public override string ToString()
     {
-        var connectionString = base.ToString();
+        var sb = new StringBuilder(base.ToString());
         if (!String.IsNullOrEmpty(_bucket))
-            connectionString += "Bucket=" + Bucket + ";";
-        return connectionString;
+            sb.Append("Bucket=").Append(Bucket).Append(';');
+        return sb.ToString();
     }
 }

--- a/src/Foundatio.Minio/Storage/MinioFileStorageConnectionStringBuilder.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorageConnectionStringBuilder.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Storage;
 
 public class MinioFileStorageConnectionStringBuilder : MinioConnectionStringBuilder
 {
-    private string _bucket = string.Empty;
+    private string _bucket = String.Empty;
 
     public MinioFileStorageConnectionStringBuilder()
     {
@@ -16,7 +16,7 @@ public class MinioFileStorageConnectionStringBuilder : MinioConnectionStringBuil
 
     public string Bucket
     {
-        get => string.IsNullOrEmpty(_bucket) ? "storage" : _bucket;
+        get => String.IsNullOrEmpty(_bucket) ? "storage" : _bucket;
         set => _bucket = value;
     }
 
@@ -33,7 +33,7 @@ public class MinioFileStorageConnectionStringBuilder : MinioConnectionStringBuil
     public override string ToString()
     {
         var connectionString = base.ToString();
-        if (!string.IsNullOrEmpty(_bucket))
+        if (!String.IsNullOrEmpty(_bucket))
             connectionString += "Bucket=" + Bucket + ";";
         return connectionString;
     }

--- a/src/Foundatio.Minio/Storage/MinioFileStorageOptions.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorageOptions.cs
@@ -12,8 +12,7 @@ public class MinioFileStorageOptionsBuilder : SharedOptionsBuilder<MinioFileStor
 {
     public MinioFileStorageOptionsBuilder ConnectionString(string connectionString)
     {
-        if (String.IsNullOrEmpty(connectionString))
-            throw new ArgumentNullException(nameof(connectionString));
+        ArgumentException.ThrowIfNullOrEmpty(connectionString);
         Target.ConnectionString = connectionString;
         return this;
     }

--- a/src/Foundatio.Minio/Storage/MinioFileStorageOptions.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorageOptions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Storage;
 
 public class MinioFileStorageOptions : SharedOptions
 {
-    public string ConnectionString { get; set; } = null!;
+    public string? ConnectionString { get; set; }
     public bool AutoCreateBucket { get; set; }
 }
 

--- a/src/Foundatio.Minio/Storage/MinioFileStorageOptions.cs
+++ b/src/Foundatio.Minio/Storage/MinioFileStorageOptions.cs
@@ -4,7 +4,7 @@ namespace Foundatio.Storage;
 
 public class MinioFileStorageOptions : SharedOptions
 {
-    public string ConnectionString { get; set; }
+    public string ConnectionString { get; set; } = null!;
     public bool AutoCreateBucket { get; set; }
 }
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.Minio.Tests/ConnectionStringBuilderTests.cs
+++ b/tests/Foundatio.Minio.Tests/ConnectionStringBuilderTests.cs
@@ -22,7 +22,7 @@ public abstract class ConnectionStringBuilderTests
             var connectionStringBuilder = CreateConnectionStringBuilder($"{key}=TestAccessKey;SecretKey=TestSecretKey;");
             Assert.Equal("TestAccessKey", connectionStringBuilder.AccessKey);
             Assert.Equal("TestSecretKey", connectionStringBuilder.SecretKey);
-            Assert.Empty(connectionStringBuilder.Region);
+            Assert.Null(connectionStringBuilder.Region);
         }
     }
 
@@ -33,7 +33,7 @@ public abstract class ConnectionStringBuilderTests
             var connectionStringBuilder = CreateConnectionStringBuilder($"AccessKey=TestAccessKey;{key}=TestSecretKey;");
             Assert.Equal("TestAccessKey", connectionStringBuilder.AccessKey);
             Assert.Equal("TestSecretKey", connectionStringBuilder.SecretKey);
-            Assert.Empty(connectionStringBuilder.Region);
+            Assert.Null(connectionStringBuilder.Region);
         }
     }
 

--- a/tests/Foundatio.Minio.Tests/ConnectionStringBuilderTests.cs
+++ b/tests/Foundatio.Minio.Tests/ConnectionStringBuilderTests.cs
@@ -22,7 +22,7 @@ public abstract class ConnectionStringBuilderTests
             var connectionStringBuilder = CreateConnectionStringBuilder($"{key}=TestAccessKey;SecretKey=TestSecretKey;");
             Assert.Equal("TestAccessKey", connectionStringBuilder.AccessKey);
             Assert.Equal("TestSecretKey", connectionStringBuilder.SecretKey);
-            Assert.Null(connectionStringBuilder.Region);
+            Assert.Empty(connectionStringBuilder.Region);
         }
     }
 
@@ -33,7 +33,7 @@ public abstract class ConnectionStringBuilderTests
             var connectionStringBuilder = CreateConnectionStringBuilder($"AccessKey=TestAccessKey;{key}=TestSecretKey;");
             Assert.Equal("TestAccessKey", connectionStringBuilder.AccessKey);
             Assert.Equal("TestSecretKey", connectionStringBuilder.SecretKey);
-            Assert.Null(connectionStringBuilder.Region);
+            Assert.Empty(connectionStringBuilder.Region);
         }
     }
 

--- a/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageConnectionStringBuilderTests.cs
+++ b/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageConnectionStringBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿using Foundatio.Storage;
+using Foundatio.Storage;
 using Xunit;
 
 namespace Foundatio.Minio.Tests.Storage;
@@ -60,7 +60,7 @@ public class MinioFileStorageConnectionStringBuilderTests : ConnectionStringBuil
             Assert.Equal("TestAccessKey", connectionStringBuilder.AccessKey);
             Assert.Equal("TestSecretKey", connectionStringBuilder.SecretKey);
             Assert.Equal("TestBucket", ((MinioFileStorageConnectionStringBuilder)connectionStringBuilder).Bucket);
-            Assert.Null(connectionStringBuilder.Region);
+            Assert.Empty(connectionStringBuilder.Region);
         }
     }
 

--- a/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageConnectionStringBuilderTests.cs
+++ b/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageConnectionStringBuilderTests.cs
@@ -60,7 +60,7 @@ public class MinioFileStorageConnectionStringBuilderTests : ConnectionStringBuil
             Assert.Equal("TestAccessKey", connectionStringBuilder.AccessKey);
             Assert.Equal("TestSecretKey", connectionStringBuilder.SecretKey);
             Assert.Equal("TestBucket", ((MinioFileStorageConnectionStringBuilder)connectionStringBuilder).Bucket);
-            Assert.Empty(connectionStringBuilder.Region);
+            Assert.Null(connectionStringBuilder.Region);
         }
     }
 

--- a/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
+++ b/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
@@ -23,8 +23,8 @@ public class MinioFileStorageTests : FileStorageTestsBase
             EndPoint = section["ENDPOINT"]!,
             Bucket = BUCKET_NAME
         };
-        if (String.IsNullOrEmpty(connectionStringBuilder.AccessKey) || String.IsNullOrEmpty(connectionStringBuilder.SecretKey))
-            throw new InvalidOperationException("Minio AccessKey and SecretKey must be configured to run integration tests. Set Minio:ACCESS_KEY_ID and Minio:SECRET_ACCESS_KEY in test configuration.");
+        if (String.IsNullOrEmpty(connectionStringBuilder.AccessKey) || String.IsNullOrEmpty(connectionStringBuilder.SecretKey) || String.IsNullOrEmpty(connectionStringBuilder.EndPoint))
+            throw new InvalidOperationException("Minio AccessKey, SecretKey, and EndPoint must be configured to run integration tests. Set Minio:ACCESS_KEY_ID, Minio:SECRET_ACCESS_KEY, and Minio:ENDPOINT in test configuration.");
 
         return new MinioFileStorage(o => o.ConnectionString(connectionStringBuilder.ToString()).AutoCreateBuckets().LoggerFactory(Log));
     }

--- a/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
+++ b/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
@@ -13,18 +13,18 @@ public class MinioFileStorageTests : FileStorageTestsBase
 
     public MinioFileStorageTests(ITestOutputHelper output) : base(output) { }
 
-    protected override IFileStorage GetStorage()
+    protected override IFileStorage? GetStorage()
     {
         var section = Configuration.GetSection("Minio");
         var connectionStringBuilder = new MinioFileStorageConnectionStringBuilder
         {
-            AccessKey = section["ACCESS_KEY_ID"] ?? String.Empty,
-            SecretKey = section["SECRET_ACCESS_KEY"] ?? String.Empty,
-            EndPoint = section["ENDPOINT"] ?? String.Empty,
+            AccessKey = section["ACCESS_KEY_ID"],
+            SecretKey = section["SECRET_ACCESS_KEY"],
+            EndPoint = section["ENDPOINT"],
             Bucket = BUCKET_NAME
         };
-        if (String.IsNullOrEmpty(connectionStringBuilder.AccessKey) || String.IsNullOrEmpty(connectionStringBuilder.SecretKey) || String.IsNullOrEmpty(connectionStringBuilder.EndPoint))
-            throw new InvalidOperationException("Minio AccessKey, SecretKey, and EndPoint must be configured to run integration tests. Set Minio:ACCESS_KEY_ID, Minio:SECRET_ACCESS_KEY, and Minio:ENDPOINT in test configuration.");
+        if (String.IsNullOrEmpty(connectionStringBuilder.AccessKey) || String.IsNullOrEmpty(connectionStringBuilder.SecretKey))
+            return null;
 
         return new MinioFileStorage(o => o.ConnectionString(connectionStringBuilder.ToString()).AutoCreateBuckets().LoggerFactory(Log));
     }

--- a/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
+++ b/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
@@ -18,9 +18,9 @@ public class MinioFileStorageTests : FileStorageTestsBase
         var section = Configuration.GetSection("Minio");
         var connectionStringBuilder = new MinioFileStorageConnectionStringBuilder
         {
-            AccessKey = section["ACCESS_KEY_ID"]!,
-            SecretKey = section["SECRET_ACCESS_KEY"]!,
-            EndPoint = section["ENDPOINT"]!,
+            AccessKey = section["ACCESS_KEY_ID"] ?? String.Empty,
+            SecretKey = section["SECRET_ACCESS_KEY"] ?? String.Empty,
+            EndPoint = section["ENDPOINT"] ?? String.Empty,
             Bucket = BUCKET_NAME
         };
         if (String.IsNullOrEmpty(connectionStringBuilder.AccessKey) || String.IsNullOrEmpty(connectionStringBuilder.SecretKey) || String.IsNullOrEmpty(connectionStringBuilder.EndPoint))

--- a/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
+++ b/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
@@ -18,13 +18,13 @@ public class MinioFileStorageTests : FileStorageTestsBase
         var section = Configuration.GetSection("Minio");
         var connectionStringBuilder = new MinioFileStorageConnectionStringBuilder
         {
-            AccessKey = section["ACCESS_KEY_ID"],
-            SecretKey = section["SECRET_ACCESS_KEY"],
-            EndPoint = section["ENDPOINT"],
+            AccessKey = section["ACCESS_KEY_ID"]!,
+            SecretKey = section["SECRET_ACCESS_KEY"]!,
+            EndPoint = section["ENDPOINT"]!,
             Bucket = BUCKET_NAME
         };
         if (String.IsNullOrEmpty(connectionStringBuilder.AccessKey) || String.IsNullOrEmpty(connectionStringBuilder.SecretKey))
-            return null;
+            return null!;
 
         return new MinioFileStorage(o => o.ConnectionString(connectionStringBuilder.ToString()).AutoCreateBuckets().LoggerFactory(Log));
     }

--- a/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
+++ b/tests/Foundatio.Minio.Tests/Storage/MinioFileStorageTests.cs
@@ -24,7 +24,7 @@ public class MinioFileStorageTests : FileStorageTestsBase
             Bucket = BUCKET_NAME
         };
         if (String.IsNullOrEmpty(connectionStringBuilder.AccessKey) || String.IsNullOrEmpty(connectionStringBuilder.SecretKey))
-            return null!;
+            throw new InvalidOperationException("Minio AccessKey and SecretKey must be configured to run integration tests. Set Minio:ACCESS_KEY_ID and Minio:SECRET_ACCESS_KEY in test configuration.");
 
         return new MinioFileStorage(o => o.ConnectionString(connectionStringBuilder.ToString()).AutoCreateBuckets().LoggerFactory(Log));
     }


### PR DESCRIPTION
## Summary
- Replaced ineffective \<WarningsAsErrors>true</WarningsAsErrors>\ with correct \<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\
- Fixed nullable reference annotations in Minio storage provider

## Test plan
- [x] \dotnet build Foundatio.All.slnx\ — 0 warnings, 0 errors